### PR TITLE
Fix error with empty liteServers array

### DIFF
--- a/mytoncore.py
+++ b/mytoncore.py
@@ -34,7 +34,7 @@ class LiteClient:
 			args = [self.appPath, "--addr", self.addr, "--pub", self.pubkeyPath, "--verbosity", "0", "--cmd", cmd]
 		else:
 			liteServers = local.db.get("liteServers")
-			if liteServers is not None:
+			if liteServers is not None and len(liteServers):
 				index = random.choice(liteServers)
 				index = str(index)
 				args += ["-i", index]


### PR DESCRIPTION
Fixes potential problem with `Error: Cannot choose from an empty sequence` error message when liteServers configuration parameter is empty.