### PR TITLE
fix: fix missing pyopenssl for json-rpc

### DIFF
--- a/scripts/jsonrpcinstaller.sh
+++ b/scripts/jsonrpcinstaller.sh
@@ -21,7 +21,7 @@ ENDC='\033[0m'
 
 # Установка компонентов python3
 echo -e "${COLOR}[1/4]${ENDC} Installing required packages"
-pip3 install Werkzeug json-rpc
+pip3 install Werkzeug json-rpc pyopenssl
 
 # Клонирование репозиториев с github.com
 echo -e "${COLOR}[2/4]${ENDC} Cloning github repository"


### PR DESCRIPTION
On some systems `pyopenssl` is not installed and rpc is not working