### PR TITLE
Upgrade the build tool to Ninja, fix some bugs

### DIFF
--- a/scripts/toninstaller.sh
+++ b/scripts/toninstaller.sh
@@ -38,6 +38,8 @@ if [ "$OSTYPE" == "linux-gnu" ]; then
 		yum install -y epel-release
 		dnf config-manager --set-enabled PowerTools
 		yum install -y git make cmake clang gflags gflags-devel zlib zlib-devel openssl-devel openssl-libs readline-devel libmicrohttpd python3 python3-pip python36-devel
+		# Install ninja
+		yum install -y ninja-build
 	elif [ -f /etc/SuSE-release ]; then
 		echo "Suse Linux detected."
 		echo "This OS is not supported with this script at present. Sorry."
@@ -47,10 +49,14 @@ if [ "$OSTYPE" == "linux-gnu" ]; then
 		echo "Arch Linux detected."
 		pacman -Syuy
 		pacman -S --noconfirm git make cmake clang gflags zlib openssl readline libmicrohttpd python python-pip
+		# install ninja
+		pacman -S  --noconfirm ninja
 	elif [ -f /etc/debian_version ]; then
 		echo "Ubuntu/Debian Linux detected."
 		apt-get update
 		apt-get install -y build-essential git make cmake clang libgflags-dev zlib1g-dev libssl-dev libreadline-dev libmicrohttpd-dev pkg-config libgsl-dev python3 python3-dev python3-pip
+		# Install ninja
+		apt-get install -y ninja-build
 	else
 		echo "Unknown Linux distribution."
 		echo "This OS is not supported with this script at present. Sorry."
@@ -68,6 +74,8 @@ elif [[ "$OSTYPE" =~ darwin.* ]]; then
 	
 	su $LOCAL_USERNAME -c "brew update"
 	su $LOCAL_USERNAME -c "brew install openssl cmake llvm"
+	# Install ninja
+	su $LOCAL_USERNAME -c "brew install ninja"
 elif [ "$OSTYPE" == "freebsd"* ]; then
 	echo "FreeBSD detected."
 	echo "This OS is not supported with this script at present. Sorry."
@@ -113,12 +121,12 @@ fi
 if [[ "$OSTYPE" =~ darwin.* ]]; then
 	if [[ $(uname -p) == 'arm' ]]; then
 		echo M1
-		CC="clang -mcpu=apple-a14" CXX="clang++ -mcpu=apple-a14" cmake $SOURCES_DIR/ton -DCMAKE_BUILD_TYPE=Release -DTON_ARCH= -Wno-dev
+		CC="clang -mcpu=apple-a14" CXX="clang++ -mcpu=apple-a14" cmake $SOURCES_DIR/ton -DCMAKE_BUILD_TYPE=Release -DTON_ARCH= -Wno-dev -GNinja
 	else
-		cmake -DCMAKE_BUILD_TYPE=Release $SOURCES_DIR/ton
+		cmake -DCMAKE_BUILD_TYPE=Release $SOURCES_DIR/ton -GNinja
 	fi
 else
-	cmake -DCMAKE_BUILD_TYPE=Release $SOURCES_DIR/ton
+	cmake -DCMAKE_BUILD_TYPE=Release $SOURCES_DIR/ton -GNinja
 fi
 
 # Компилируем из исходников
@@ -135,7 +143,7 @@ else
 fi
 
 echo "use ${cpuNumber} cpus"
-make -j ${cpuNumber} fift validator-engine lite-client pow-miner validator-engine-console generate-random-id dht-server func tonlibjson rldp-http-proxy
+ninja -j ${cpuNumber} fift validator-engine lite-client pow-miner validator-engine-console generate-random-id dht-server func tonlibjson rldp-http-proxy
 
 # Скачиваем конфигурационные файлы lite-client
 echo -e "${COLOR}[5/6]${ENDC} Downloading config files"

--- a/scripts/toninstaller.sh
+++ b/scripts/toninstaller.sh
@@ -33,36 +33,71 @@ fi
 # Установка требуемых пакетов
 echo -e "${COLOR}[1/6]${ENDC} Installing required packages"
 if [ "$OSTYPE" == "linux-gnu" ]; then
-	if [ hash yum 2>/dev/null ]; then
-		echo "RHEL-based Linux detected."
+
+	# Determine if it is a CentOS system
+	if cat /etc/*release | grep ^NAME | grep CentOS ; then
+		echo "CentOS Linux detected."
+		yum update -y
 		yum install -y epel-release
-		dnf config-manager --set-enabled PowerTools
-		yum install -y git make cmake clang gflags gflags-devel zlib zlib-devel openssl-devel openssl-libs readline-devel libmicrohttpd python3 python3-pip python36-devel
+		yum install -y git gflags gflags-devel zlib zlib-devel openssl-devel openssl-libs readline-devel libmicrohttpd python3 python3-pip python36-devel g++ gcc libstdc++-devel zlib1g-dev libssl-dev which make gcc-c++ libstdc++-devel 
+		
+		# Upgrade make and gcc in CentOS system
+		yum install centos-release-scl -y
+		yum install devtoolset-10 -y
+		echo "source /opt/rh/devtoolset-10/enable" >> /etc/bashrc
+		source /opt/rh/devtoolset-10/enable
+
+		# Install the new version of CMake
+		yum remove cmake -y
+		wget https://cmake.org/files/v3.24/cmake-3.24.2.tar.gz
+		tar -zxvf cmake-3.24.2.tar.gz
+		cd cmake-3.24.2 && ./bootstrap && make -j -j$(nproc) && make install
+		yum remove cmake -y
+		ln -s /usr/local/bin/cmake /usr/bin/cmake
+		source ~/.bashrc
+		cmake --version
+
 		# Install ninja
 		yum install -y ninja-build
+
+	# Red Hat systems are not supported
+	elif cat /etc/*release | grep ^NAME | grep Red ; then
+		echo "Red Hat Linux detected."
+		echo "This OS is not supported with this script at present. Sorry."
+		echo "Please refer to https://github.com/ton-blockchain/mytonctrl for setup information."
+		exit 1
+	
+	# Suse systems are not supported
 	elif [ -f /etc/SuSE-release ]; then
 		echo "Suse Linux detected."
 		echo "This OS is not supported with this script at present. Sorry."
 		echo "Please refer to https://github.com/ton-blockchain/mytonctrl for setup information."
 		exit 1
+
 	elif [ -f /etc/arch-release ]; then
 		echo "Arch Linux detected."
-		pacman -Syuy
-		pacman -S --noconfirm git make cmake clang gflags zlib openssl readline libmicrohttpd python python-pip
-		# install ninja
+		pacman -Syuy  --noconfirm
+		pacman -S --noconfirm git cmake clang gflags zlib openssl readline libmicrohttpd python python-pip
+
+		# Install ninja
 		pacman -S  --noconfirm ninja
+
 	elif [ -f /etc/debian_version ]; then
 		echo "Ubuntu/Debian Linux detected."
 		apt-get update
-		apt-get install -y build-essential git make cmake clang libgflags-dev zlib1g-dev libssl-dev libreadline-dev libmicrohttpd-dev pkg-config libgsl-dev python3 python3-dev python3-pip
+		apt-get install -y build-essential git cmake clang libgflags-dev zlib1g-dev libssl-dev libreadline-dev libmicrohttpd-dev pkg-config libgsl-dev python3 python3-dev python3-pip
+
 		# Install ninja
 		apt-get install -y ninja-build
+
 	else
 		echo "Unknown Linux distribution."
 		echo "This OS is not supported with this script at present. Sorry."
 		echo "Please refer to https://github.com/ton-blockchain/mytonctrl for setup information."
 		exit 1
 	fi
+
+# Detected mac os system.	
 elif [[ "$OSTYPE" =~ darwin.* ]]; then
 	echo "Mac OS (Darwin) detected."
 	if [ ! which brew >/dev/null 2>&1 ]; then
@@ -74,8 +109,10 @@ elif [[ "$OSTYPE" =~ darwin.* ]]; then
 	
 	su $LOCAL_USERNAME -c "brew update"
 	su $LOCAL_USERNAME -c "brew install openssl cmake llvm"
+
 	# Install ninja
 	su $LOCAL_USERNAME -c "brew install ninja"
+
 elif [ "$OSTYPE" == "freebsd"* ]; then
 	echo "FreeBSD detected."
 	echo "This OS is not supported with this script at present. Sorry."
@@ -98,7 +135,6 @@ rm -rf $SOURCES_DIR/ton
 rm -rf $SOURCES_DIR/mytonctrl
 git clone --recursive https://github.com/ton-blockchain/ton.git
 git clone --recursive https://github.com/ton-blockchain/mytonctrl.git
-
 
 # Подготавливаем папки для компиляции
 echo -e "${COLOR}[3/6]${ENDC} Preparing for compilation"
@@ -126,7 +162,7 @@ if [[ "$OSTYPE" =~ darwin.* ]]; then
 		cmake -DCMAKE_BUILD_TYPE=Release $SOURCES_DIR/ton -GNinja
 	fi
 else
-	cmake -DCMAKE_BUILD_TYPE=Release $SOURCES_DIR/ton -GNinja
+	cmake -DCMAKE_BUILD_TYPE=Release $SOURCES_DIR/ton -GNinja 
 fi
 
 # Компилируем из исходников


### PR DESCRIPTION
Switching to the ninja compiler can reduce compilation time by up to 40%.

related issue :  https://github.com/ton-blockchain/mytonctrl/issues/99
@neodiX42 Please help me test if you have time

Global:
* Replace all `make` compilation methods with `ninja`
* remove all `make` methods
* Install `ninja` method
* Fix the original precompile method, add the `-GNinja` flag
* Corrected the detection method of the system, and listed the Red Hat system as unsupported

yum
* In the centos system, `cmake` is updated to the latest version or 2.x, and ton cannot be compiled
* `cmake` version lower than 3.9 cannot compile `rocksdb`
* Download, compile, install version `cmake` 3.24.2
* Add install `switch` method - need to recognize environment variables
* Fix the method of not recognizing yum system
* Remove invalid command `dnf config-manager --set-enabled PowerTools`
* Install `devtoolset-10` and activate it. Make the system support the new `make` and `gcc` methods.

pacman
* Add `--noconfirm` method during installation, automatic installation

---

Test run toninstaller.sh
> * Except macos is a physical machine test, others are docker images.
> * I built the test script here and it has been tested https://github.com/TonX-Studio/test-mytonctrl-tools-docker

| system environment            |  Test Results  |
|:----------------------------- |:--------------:|
| ubuntu:18.04                  | Test passed ✅ |
| ubuntu:20.04                  | Test passed ✅ |
| ubuntu:22.04                  | Test passed ✅ |
| debian:10                     | Test passed ✅ |
| debian:11                     | Test passed ✅ |
| archlinux:base                | Test passed ✅ |
| centos: centos7.9.2009        | Test passed ✅ |
| mac os 13.0 Beta Apple M1 Max | Test passed ✅ |

debian:8 / debian:9 / ubuntu:16.04
> * It looks like the system version is too old. I feel no need to maintain all three versions.
> * To solve this problem we need to recompile the new version of cmake.
```
Add rocksdb
CMake Error at third-party/rocksdb/CMakeLists.txt:35 (cmake_minimum_required):
  CMake 3.10 or higher is required.  You are running version 3.7.2

```
