### PR TITLE
Fix upgrade on hosts with small RAM size

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -44,7 +44,7 @@ export CCACHE_DISABLE=1
 cd ${bindir}/${repo}
 rm -f CMakeCache.txt
 memory=$(cat /proc/meminfo | grep MemAvailable | awk '{print $2}')
-let "cpuNumber = memory / 2100000"
+let "cpuNumber = memory / 2100000" || cpuNumber=1
 cmake -DCMAKE_BUILD_TYPE=Release ${srcdir}/${repo}
 make -j ${cpuNumber} fift validator-engine lite-client pow-miner validator-engine-console generate-random-id dht-server func tonlibjson rldp-http-proxy
 systemctl restart validator


### PR DESCRIPTION
На системах с ОЗУ < 2100 Мб команда `let` отдаёт код 1, если значение `cpuNumber` равно 0. Скрипт сразу падает без пояснения. Данный хост не используется как нода, поэтому памяти на нём меньше. 

![image](https://user-images.githubusercontent.com/104140659/231407076-99e805b5-33aa-44ee-85f3-482cda1f0e16.png)

```
$ let --help
let: let arg [arg ...]
    Evaluate arithmetic expressions.
    
    Exit Status:
    If the last ARG evaluates to 0, let returns 1; let returns 0 otherwise.
```