### PR TITLE
add ubuntu 22.04 to the list of tested OS

### DIFF
--- a/README.Ru.md
+++ b/README.Ru.md
@@ -46,6 +46,7 @@
 Ubuntu 16.04 LTS (Xenial Xerus) - Error: TON compilation error
 Ubuntu 18.04 LTS (Bionic Beaver) - OK
 Ubuntu 20.04 LTS (Focal Fossa) - OK
+Ubuntu 22.04 LTS (Jammy Jellyfish) - OK
 Debian 8 - Error: Unable to locate package libgsl-dev
 Debian 9 - Error: TON compilation error
 Debian 10 - OK

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This console is a wrapper over `fift`,`lite-client` and `validator-engine-consol
 Ubuntu 16.04 LTS (Xenial Xerus) - Error: TON compilation error
 Ubuntu 18.04 LTS (Bionic Beaver) - OK
 Ubuntu 20.04 LTS (Focal Fossa) - OK
+Ubuntu 22.04 LTS (Jammy Jellyfish) - OK
 Debian 8 - Error: Unable to locate package libgsl-dev
 Debian 9 - Error: TON compilation error
 Debian 10 - OK


### PR DESCRIPTION
I've been using this tool only on Ubuntu 22.04 so far and didn't have any troubles.