### PR TITLE
Perform validator upgrade with Ninja

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -45,10 +45,8 @@ export CCACHE_DISABLE=1
 
 # Update binary
 cd ${bindir}/${repo}
-cp global.config.json /tmp
-rm -rf *
+ls --hide=global.config.json | xargs -d '\n' rm -rf
 rm -rf .ninja_*
-mv /tmp/global.config.json .
 memory=$(cat /proc/meminfo | grep MemAvailable | awk '{print $2}')
 let "cpuNumber = memory / 2100000" || cpuNumber=1
 cmake -DCMAKE_BUILD_TYPE=Release ${srcdir}/${repo} -GNinja

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -44,11 +44,10 @@ export CXX=/usr/bin/clang++
 export CCACHE_DISABLE=1
 
 # Update binary
-cd ${bindir}
-cp ${repo}/global.config.json /tmp
-rm -rf ${repo}
-mkdir ${repo}
-cd ${repo}
+cd ${bindir}/${repo}
+cp global.config.json /tmp
+rm -rf *
+rm -rf .ninja_*
 mv /tmp/global.config.json .
 memory=$(cat /proc/meminfo | grep MemAvailable | awk '{print $2}')
 let "cpuNumber = memory / 2100000" || cpuNumber=1

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -28,7 +28,7 @@ done
 COLOR='\033[92m'
 ENDC='\033[0m'
 
-# Установить дополниьтельные зависимости
+# Установить дополнительные зависимости
 apt-get install -y libsecp256k1-dev libsodium-dev
 
 # Go to work dir
@@ -44,12 +44,14 @@ export CXX=/usr/bin/clang++
 export CCACHE_DISABLE=1
 
 # Update binary
-cd ${bindir}/${repo}
-rm -f CMakeCache.txt
+cd ${bindir}
+rm -rf ${repo}
+mkdir ${repo}
+cd ${repo}
 memory=$(cat /proc/meminfo | grep MemAvailable | awk '{print $2}')
 let "cpuNumber = memory / 2100000" || cpuNumber=1
-cmake -DCMAKE_BUILD_TYPE=Release ${srcdir}/${repo}
-make -j ${cpuNumber} fift validator-engine lite-client pow-miner validator-engine-console generate-random-id dht-server func tonlibjson rldp-http-proxy
+cmake -DCMAKE_BUILD_TYPE=Release ${srcdir}/${repo} -GNinja
+ninja -j ${cpuNumber} fift validator-engine lite-client pow-miner validator-engine-console generate-random-id dht-server func tonlibjson rldp-http-proxy
 systemctl restart validator
 
 # Конец

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -45,11 +45,11 @@ export CCACHE_DISABLE=1
 
 # Update binary
 cd ${bindir}
-cp ${repo}/global.config.json .
+cp ${repo}/global.config.json /tmp
 rm -rf ${repo}
 mkdir ${repo}
 cd ${repo}
-cp ../global.config.json .
+mv /tmp/global.config.json .
 memory=$(cat /proc/meminfo | grep MemAvailable | awk '{print $2}')
 let "cpuNumber = memory / 2100000" || cpuNumber=1
 cmake -DCMAKE_BUILD_TYPE=Release ${srcdir}/${repo} -GNinja

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -45,9 +45,11 @@ export CCACHE_DISABLE=1
 
 # Update binary
 cd ${bindir}
+cp ${repo}/global.config.json .
 rm -rf ${repo}
 mkdir ${repo}
 cd ${repo}
+cp ../global.config.json .
 memory=$(cat /proc/meminfo | grep MemAvailable | awk '{print $2}')
 let "cpuNumber = memory / 2100000" || cpuNumber=1
 cmake -DCMAKE_BUILD_TYPE=Release ${srcdir}/${repo} -GNinja


### PR DESCRIPTION
This PR cleans up properly the build directory before the upgrade and performs the upgrade using Ninja tool.

If you have running dht-server or any other process (apart validator-engine) that is based on binaries located under _/usr/bin/ton/_ do not forget to restart it.