### PR TITLE
fix toninstaller.sh

### DIFF
--- a/scripts/toninstaller.sh
+++ b/scripts/toninstaller.sh
@@ -125,7 +125,7 @@ else
 fi
 
 # Установка компонентов python3
-pip3 install psutil fastcrc requests
+pip3 install --break-system-packages psutil fastcrc requests
 
 # Клонирование репозиториев с github.com
 echo -e "${COLOR}[2/6]${ENDC} Cloning github repository"


### PR DESCRIPTION
added flag `--break-system-packages` to pip3 install, because just now it may breaks installation process

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```