### PR TITLE
Update installation branch from "master" to "mytonctrl2"

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,7 @@ fi
 
 author="ton-blockchain"
 repo="mytonctrl"
-branch="master"
+branch="mytonctrl2"
 mode="validator"
 
 show_help_and_exit() {


### PR DESCRIPTION
This fix allows to install mytonctrl2 directly from the mytonctrl2 branch. Otherwise, you need to install mytonctrl1 first and then update it to mytonctrl2.