### PR TITLE
Fixes setuptools dependency issue

### DIFF
--- a/mytonctrl/scripts/update.sh
+++ b/mytonctrl/scripts/update.sh
@@ -39,6 +39,7 @@ pip3 uninstall -y mytonctrl
 echo "https://github.com/${author}/${repo}.git -> ${branch}"
 git clone --recursive https://github.com/${author}/${repo}.git
 cd ${repo} && git checkout ${branch}
+pip3 install -r requirements.txt
 pip3 install -U .
 
 systemctl daemon-reload

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests==2.32.3
 psutil==6.1.0
 fastcrc==0.3.2
 pynacl==1.5.0
+setuptools<=70.3.0


### PR DESCRIPTION
If setuptools is updated to >70.3.0 it will break mytonctrl update due to a bug: https://github.com/pypa/setuptools/issues/4483
As a workaround, I've pinned the setuptools to <=70.3.0 and added the requirements installation before setup.py. If this is not added, the setup.py will fail due to this bug and not update setuptools to the correct version. 

Error when setuptools >70.3.0 is installed: 

```
Processing /usr/src/mytonctrl
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [43 lines of output]
      /usr/local/lib/python3.10/dist-packages/setuptools/dist.py:330: InformationOnly: Normalizing 'v0.1' to '0.1'
        self.metadata.version = self._normalize_version(self.metadata.version)
      running egg_info
      creating /tmp/pip-pip-egg-info-d2objj6s/mytonctrl.egg-info
      writing /tmp/pip-pip-egg-info-d2objj6s/mytonctrl.egg-info/PKG-INFO
      writing dependency_links to /tmp/pip-pip-egg-info-d2objj6s/mytonctrl.egg-info/dependency_links.txt
      writing requirements to /tmp/pip-pip-egg-info-d2objj6s/mytonctrl.egg-info/requires.txt
      writing top-level names to /tmp/pip-pip-egg-info-d2objj6s/mytonctrl.egg-info/top_level.txt
      writing manifest file '/tmp/pip-pip-egg-info-d2objj6s/mytonctrl.egg-info/SOURCES.txt'
      reading manifest file '/tmp/pip-pip-egg-info-d2objj6s/mytonctrl.egg-info/SOURCES.txt'
      adding license file 'LICENSE'
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/usr/src/mytonctrl/setup.py", line 12, in <module>
          setup(
        File "/usr/local/lib/python3.10/dist-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/core.py", line 183, in setup
          return run_commands(dist)
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/core.py", line 199, in run_commands
          dist.run_commands()
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/dist.py", line 954, in run_commands
          self.run_command(cmd)
        File "/usr/local/lib/python3.10/dist-packages/setuptools/dist.py", line 995, in run_command
          super().run_command(command)
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/dist.py", line 973, in run_command
          cmd_obj.run()
        File "/usr/local/lib/python3.10/dist-packages/setuptools/command/egg_info.py", line 313, in run
          self.find_sources()
        File "/usr/local/lib/python3.10/dist-packages/setuptools/command/egg_info.py", line 321, in find_sources
          mm.run()
        File "/usr/local/lib/python3.10/dist-packages/setuptools/command/egg_info.py", line 549, in run
          self.prune_file_list()
        File "/usr/local/lib/python3.10/dist-packages/setuptools/command/sdist.py", line 162, in prune_file_list
          super().prune_file_list()
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/command/sdist.py", line 380, in prune_file_list
          base_dir = self.distribution.get_fullname()
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_core_metadata.py", line 267, in get_fullname
          return _distribution_fullname(self.get_name(), self.get_version())
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_core_metadata.py", line 285, in _distribution_fullname
          canonicalize_version(version, strip_trailing_zero=False),
      TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.

[notice] A new release of pip is available: 24.2 -> 24.3.1
[notice] To update, run: python3 -m pip install --upgrade pip
error: metadata-generation-failed
```