### PR TITLE
Respect process error code when run fift

### DIFF
--- a/mytoncore/fift.py
+++ b/mytoncore/fift.py
@@ -19,7 +19,7 @@ class Fift:
 		process = subprocess.run(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout)
 		output = process.stdout.decode("utf-8")
 		err = process.stderr.decode("utf-8")
-		if len(err) > 0:
+		if process.returncode != 0 and len(err) > 0:
 			self.local.add_log("args: {args}".format(args=args), "error")
 			raise Exception("Fift error: {err}".format(err=err))
 		return output


### PR DESCRIPTION
Default verbosity level of fift is INFO https://github.com/ton-blockchain/ton/blob/master/crypto/fift/fift-main.cpp#L98 which overrides WARNING not only ERROR (https://github.com/ton-blockchain/ton/blob/master/tdutils/td/utils/logging.h#L121) which results in a single warning line to fail fift execution.