### PR TITLE
allow custom git URLs (https, ssh, git@) for TON node

### DIFF
--- a/mytonctrl/mytonctrl.py
+++ b/mytonctrl/mytonctrl.py
@@ -345,8 +345,15 @@ def Upgrade(local, ton, args: list):
 			branch = args[args.index('--btc-teleport') + 1]
 		upgrade_btc_teleport(local, ton, reinstall=True, branch=branch, user=user)
 		return
-	repo = "ton"
-	author, repo, branch = check_git(args, repo, "upgrade")
+
+	git_url = None
+
+	if '--url' in args and '--branch' in args:
+		git_url = args[args.index('--url') + 1]
+		branch = args[args.index('--branch') + 1]
+	else:
+		repo = "ton"
+		author, repo, branch = check_git(args, repo, "upgrade")
 
 	# bugfix if the files are in the wrong place
 	liteClient = ton.GetSettings("liteClient")
@@ -376,7 +383,11 @@ def Upgrade(local, ton, args: list):
 
 	# Run script
 	upgrade_script_path = pkg_resources.resource_filename('mytonctrl', 'scripts/upgrade.sh')
-	runArgs = ["bash", upgrade_script_path, "-a", author, "-r", repo, "-b", branch]
+	if git_url:
+		runArgs = ["bash", upgrade_script_path, "-g", git_url, "-b", branch]
+	else:
+		runArgs = ["bash", upgrade_script_path, "-a", author, "-r", repo, "-b", branch]
+
 	exitCode = run_as_root(runArgs)
 	if ton.using_validator():
 		upgrade_btc_teleport(local, ton)

--- a/mytonctrl/scripts/upgrade.sh
+++ b/mytonctrl/scripts/upgrade.sh
@@ -16,14 +16,29 @@ bindir="/usr/bin/"
 tmpdir="/tmp/ton_src/"
 
 # Get arguments
-while getopts a:r:b: flag
+while getopts a:r:b:g: flag
 do
 	case "${flag}" in
 		a) author=${OPTARG};;
 		r) repo=${OPTARG};;
 		b) branch=${OPTARG};;
+    g) git_url=${OPTARG};;
 	esac
 done
+
+remote_url="https://github.com/${author}/${repo}.git"
+if [ -n "$git_url" ]; then
+  if [[ "$git_url" == *"#"* ]]; then
+    remote_url="${git_url%%#*}"
+    ref_from_url="${git_url##*#}"
+
+    if [ "$branch" = "master" ]; then
+      branch="$ref_from_url"
+    fi
+  else
+    remote_url="$git_url"
+  fi
+fi
 
 # Цвета
 COLOR='\033[92m'
@@ -63,8 +78,8 @@ fi
 rm -rf ${tmpdir}/${repo}
 mkdir -p ${tmpdir}/${repo}
 cd ${tmpdir}/${repo}
-echo "https://github.com/${author}/${repo}.git -> ${branch}"
-git clone --recursive https://github.com/${author}/${repo}.git . || exit 1
+echo "${remote_url} -> ${branch}"
+git clone --recursive ${remote_url} . || exit 1
 
 # Go to work dir
 cd ${srcdir}/${repo}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,7 +17,7 @@ repo="mytonctrl"
 branch="master"
 network="mainnet"
 ton_node_version="master"  # Default version
-
+ton_node_git_url="https://github.com/ton-blockchain/ton.git"
 
 show_help_and_exit() {
     echo 'Supported arguments:'
@@ -28,6 +28,7 @@ show_help_and_exit() {
     echo ' -a               Set MyTonCtrl git repo author'
     echo ' -r               Set MyTonCtrl git repo'
     echo ' -b               Set MyTonCtrl git repo branch'
+    echo ' -g  URL          TON node git repo URL (default: https://github.com/ton-blockchain/ton.git)'
     echo ' -m  MODE         Install MyTonCtrl with specified mode (validator or liteserver)'
     echo ' -n  NETWORK      Specify the network (mainnet or testnet)'
     echo ' -v  VERSION      Specify the ton node version (commit, branch, or tag)'
@@ -55,14 +56,15 @@ mode=none
 cpu_required=16
 mem_required=64000000  # 64GB in KB
 
-while getopts ":c:tidola:r:b:m:n:v:u:p:h" flag; do
+while getopts ":c:tidola:r:b:m:n:v:u:p:g:h" flag; do
     case "${flag}" in
-        c) config=${OPTARG};;
+        c) config=${OPTARG}; config_overridden=true;;
         t) telemetry=false;;
         i) ignore=true;;
         d) dump=true;;
         a) author=${OPTARG};;
         r) repo=${OPTARG};;
+        g) ton_node_git_url=${OPTARG};;
         b) branch=${OPTARG};;
         m) mode=${OPTARG};;
         n) network=${OPTARG};;
@@ -100,7 +102,10 @@ fi
 
 # Set config based on network argument
 if [ "${network}" = "testnet" ]; then
-    config="https://ton-blockchain.github.io/testnet-global.config.json"
+    if [ "${config_overridden}" = false ]; then
+        config="https://ton-blockchain.github.io/testnet-global.config.json"
+    fi
+
     cpu_required=8
     mem_required=16000000  # 16GB in KB
 fi
@@ -144,7 +149,7 @@ file3=${BIN_DIR}/ton/validator-engine-console/validator-engine-console
 if  [ ! -f "${file1}" ] || [ ! -f "${file2}" ] || [ ! -f "${file3}" ]; then
     echo "TON does not exists, building"
     wget https://raw.githubusercontent.com/${author}/${repo}/${branch}/scripts/ton_installer.sh -O /tmp/ton_installer.sh
-    bash /tmp/ton_installer.sh -c ${config} -v ${ton_node_version}
+    bash /tmp/ton_installer.sh -c ${config} -g ${ton_node_git_url} -v ${ton_node_version}
 fi
 
 # Cloning mytonctrl

--- a/scripts/ton_installer.sh
+++ b/scripts/ton_installer.sh
@@ -8,8 +8,11 @@ if [ "$(id -u)" != "0" ]; then
 	exit 1
 fi
 
-while getopts ":c:v:h" flag; do
+repo_git_url="https://github.com/ton-blockchain/ton.git"
+
+while getopts ":c:v:g:h" flag; do
     case "${flag}" in
+        g) repo_git_url=${OPTARG};;
         c) config=${OPTARG};;
         v) ton_node_version=${OPTARG};;
         h) show_help_and_exit;;
@@ -108,7 +111,7 @@ make build_libs -j$(nproc)
 echo -e "${COLOR}[3/6]${ENDC} Preparing for compilation"
 cd $SOURCES_DIR
 rm -rf $SOURCES_DIR/ton
-git clone --recursive https://github.com/ton-blockchain/ton.git
+git clone --recursive $repo_git_url $SOURCES_DIR/ton
 
 echo "checkout to ${ton_node_version}"
 


### PR DESCRIPTION
Add support for installing and upgrading the TON node from any custom git URL, not just the default **https**. Both HTTPS and SSH schemas (https://, ssh://, git@) are supported, and URLs can optionally include a branch or commit reference (e.g. git@github.com:org/repo.git#dev-branch).